### PR TITLE
Make mouse picker faster

### DIFF
--- a/example-mouse-picker/src/ofApp.cpp
+++ b/example-mouse-picker/src/ofApp.cpp
@@ -44,7 +44,7 @@ void ofApp::draw(){
 
     // iterates through all the primitives and find the closest one.
     for (unsigned int i = 0; i<icospheres.size(); i++) {
-        auto ico = icospheres.at(i);
+        auto & ico = icospheres.at(i);
         ico.draw();
 
         bool intersects = mousepicker.getRay().intersectsPrimitive(ico,  baricentricCoordinates, surfaceNormal);


### PR DESCRIPTION
By not making copies of the mesh (40% faster in debug mode with 500 spheres)